### PR TITLE
Fix false primary-offline caused by trailing slash in PRIMARY_API_URL

### DIFF
--- a/serverside/secondary_api.py
+++ b/serverside/secondary_api.py
@@ -63,7 +63,12 @@ PRIMARY_API_SESSION = create_session()
 log.setLevel(logging.ERROR) """
 
 # Configuration
-PRIMARY_API_URL = os.getenv('PRIMARY_API_URL', 'http://localhost:5000/api')
+# Normalize the base URL so joins like f'{PRIMARY_API_URL}/status' never produce
+# a double slash. A trailing slash in PRIMARY_API_URL (e.g. 'http://host:5000/api/')
+# would otherwise yield 'http://host:5000/api//status', which Flask treats as a
+# different path and answers with 404 - making the secondary wrongly conclude the
+# primary is offline even though the request reached it.
+PRIMARY_API_URL = os.getenv('PRIMARY_API_URL', 'http://localhost:5000/api').rstrip('/')
 QUEUE_DB = 'request_queue.db'
 SYNC_INTERVAL = 10  # seconds
 REQUEST_TIMEOUT = 4.0  # seconds for data requests


### PR DESCRIPTION
## Problem

The secondary server kept reporting that the primary API returned **404** and concluding the primary was **offline** — even though the request visibly reached the primary. It "seemed like it worked but it didn't."

## Root cause

`secondary_api.py` builds request URLs by concatenating `PRIMARY_API_URL` with an endpoint that already starts with `/`:

```python
probe_urls = [f'{PRIMARY_API_URL}/status', PRIMARY_API_URL]
url = f'{PRIMARY_API_URL}{endpoint}'   # endpoint = "/status", "/limits", ...
```

`PRIMARY_API_URL` is typically set via `.env` (gitignored). When it carries a **trailing slash** — `http://host:5000/api/` — the joins produce a **double slash**:

```
http://host:5000/api//status
```

Flask routes `/api//status` as a distinct path from `/api/status` and returns **404**. The request genuinely arrives at the primary (hence the log line the user saw), but `check_primary_alive()` only accepts HTTP 200, so the 404 makes the secondary declare the primary offline.

## Fix

Normalize the base URL once at load with `.rstrip('/')`, so `http://host:5000/api`, `http://host:5000/api/`, and even `http://host:5000/api///` all yield clean single-slash URLs.

```python
PRIMARY_API_URL = os.getenv('PRIMARY_API_URL', 'http://localhost:5000/api').rstrip('/')
```

## Verification

Reproduced the double-slash 404 with a trailing-slash base, and confirmed the normalized base produces `http://localhost:5000/api/status` and `http://localhost:5000/api/limits` for all trailing-slash variants. Syntax-checked the module.

Note: this tolerates a trailing slash, but a `PRIMARY_API_URL` that omits `/api` entirely is still a genuinely wrong path and will 404 — worth confirming the `.env` value points at `.../api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrE4bNZXoLKDTUpE5vCr2c