### PR TITLE
Add night lockdown module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ exceptionaltime.json
 timelimit.json
 timeusage.json
 used_exceptions.json
+nightlockdown.json
 .env
 .json
 *.db

--- a/README.md
+++ b/README.md
@@ -272,7 +272,12 @@ For detailed secondary API documentation, see [serverside/SECONDARY_API_DOCS.md]
   }
 }
 ```
-Times are in seconds. Set to 0 to disable app entirely for that day.
+Times are in seconds. Set to `0` to disable an app entirely for that day
+(0 seconds allowed). Leaving a day **unset** (missing key or `null`) means
+"not configured" — the app/`OVERALL` is treated as effectively unlimited for
+that day (86399s) and is **not** restricted. This applies to `OVERALL` too, so
+an empty `timelimit.json` (`{}`) no longer shuts the computer down; it simply
+enforces nothing until you configure a limit.
 
 ### Usage Tracking Format (timeusage.json)
 ```json

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A comprehensive Windows-based parental control system that monitors application 
 - 🛡️ **Exception Management** - Grant temporary exceptions to bypass time limits for specific dates
 - 🔔 **Smart Notifications** - Toast notifications at configurable intervals (30s, 60s, 2m, 5m before limit reached)
 - 🎯 **Selective Monitoring** - Choose which applications to monitor and control
+- 🌙 **Night Lockdown** - Automatically shut the computer down during parent-defined blocked time zones, with optional whitelisted exceptions, configurable the same for every day or per day of the week
 
 ### Architecture
 - 🌐 **Distributed System** - Client-side engine with server-side dashboard integration
@@ -24,11 +25,14 @@ A comprehensive Windows-based parental control system that monitors application 
 ParentalControlsV2/
 ├── clientside/              # Local monitoring and API server
 │   ├── client_engine.py     # Main application monitor and enforcer
+│   ├── night_lockdown.py    # Night lockdown enforcer (shuts down in blocked zones)
+│   ├── client_master.py     # Launches api, engine and night lockdown together
 │   ├── api.py               # Configuration REST API (PORT 5000)
 │   ├── requirements.txt      # Python dependencies
 │   ├── timelimit.json        # Application time limits (per day)
 │   ├── timeusage.json        # Current usage statistics
 │   ├── exceptionaltime.json  # Exception dates/apps
+│   ├── nightlockdown.json    # Night lockdown blocked/whitelisted zones
 │   └── used_exceptions.json  # Tracking of used exceptions
 │
 ├── serverside/              # Central dashboard and proxy
@@ -100,6 +104,16 @@ cd clientside
 env\Scripts\activate
 python client_engine.py
 ```
+
+#### Step 2b: Start the Night Lockdown Engine
+In a new terminal:
+```bash
+cd clientside
+env\Scripts\activate
+python night_lockdown.py
+```
+> Tip: `python client_master.py` launches the API, the monitoring engine and the
+> night lockdown engine together in a single command.
 
 #### Step 3: Start Serverside Proxy Server (Optional but Recommended)
 In another terminal:
@@ -179,6 +193,32 @@ POST /api/exceptions
 DELETE /api/exceptions/{date}/{app_name}
 ```
 
+#### Night Lockdown
+```bash
+# Get night lockdown configuration
+GET /api/nightlockdown
+
+# Replace night lockdown configuration
+PUT /api/nightlockdown
+{
+  "enabled": true,
+  "per_day": false,
+  "all_days": {
+    "blocked":   [["22:00", "07:00"]],
+    "whitelist": [["23:00", "23:30"]]
+  },
+  "days": {
+    "Monday":  { "blocked": [], "whitelist": [] },
+    ...
+  }
+}
+```
+When `per_day` is `false`, the `all_days` schedule applies to every day. When
+`true`, the matching entry in `days` is used for the current weekday. If the
+current time falls inside a **blocked** window and not inside a **whitelisted**
+window, the computer is shut down. Time windows may cross midnight
+(e.g. `["22:00", "07:00"]`).
+
 #### Configuration
 ```bash
 # Get config
@@ -244,6 +284,31 @@ Times are in seconds. Set to 0 to disable app entirely for that day.
   }
 }
 ```
+
+### Night Lockdown Format (nightlockdown.json)
+```json
+{
+  "enabled": true,
+  "per_day": false,
+  "all_days": {
+    "blocked":   [["22:00", "07:00"]],
+    "whitelist": [["23:00", "23:30"]]
+  },
+  "days": {
+    "Monday":    { "blocked": [["21:00", "07:00"]], "whitelist": [] },
+    "Tuesday":   { "blocked": [], "whitelist": [] },
+    "Wednesday": { "blocked": [], "whitelist": [] },
+    "Thursday":  { "blocked": [], "whitelist": [] },
+    "Friday":    { "blocked": [], "whitelist": [] },
+    "Saturday":  { "blocked": [], "whitelist": [] },
+    "Sunday":    { "blocked": [], "whitelist": [] }
+  }
+}
+```
+Each window is a `["HH:MM", "HH:MM"]` (24-hour) pair and may wrap past midnight.
+The night lockdown engine performs a 3-minute security sleep on startup before
+it begins enforcing, and re-reads this file on every check so dashboard changes
+take effect without a restart.
 
 ### Exceptions Format (exceptionaltime.json)
 ```json

--- a/clientside/API_USAGE_EXAMPLES.md
+++ b/clientside/API_USAGE_EXAMPLES.md
@@ -162,7 +162,49 @@ curl -X DELETE http://localhost:5000/api/exceptions/2026-01-17/chrome.exe
 
 ---
 
-### 3. USAGE TRACKING
+### 3. NIGHT LOCKDOWN
+
+#### Get night lockdown configuration
+```bash
+curl http://localhost:5000/api/nightlockdown
+```
+
+#### Same schedule for every day
+```bash
+curl -X PUT http://localhost:5000/api/nightlockdown \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "per_day": false,
+    "all_days": {
+      "blocked":   [["22:00", "07:00"]],
+      "whitelist": [["23:00", "23:30"]]
+    }
+  }'
+```
+
+#### Different schedule per day of the week
+```bash
+curl -X PUT http://localhost:5000/api/nightlockdown \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "per_day": true,
+    "days": {
+      "Friday":   {"blocked": [["23:59", "08:00"]], "whitelist": []},
+      "Saturday": {"blocked": [["23:59", "09:00"]], "whitelist": []},
+      "Sunday":   {"blocked": [["21:00", "07:00"]], "whitelist": []}
+    }
+  }'
+```
+
+Windows are `["HH:MM", "HH:MM"]` (24-hour) and may cross midnight. When the
+current time is inside a **blocked** window and not inside a **whitelisted**
+window, the computer is shut down.
+
+---
+
+### 4. USAGE TRACKING
 
 #### Get all usage data
 ```bash
@@ -208,7 +250,7 @@ curl -X PUT http://localhost:5000/api/usage/2026-01-17/chrome.exe \
 
 ---
 
-### 4. STATUS & CONFIGURATION
+### 5. STATUS & CONFIGURATION
 
 #### Get current system status
 ```bash

--- a/clientside/api.py
+++ b/clientside/api.py
@@ -32,9 +32,20 @@ def add_cors_headers(response):
 LIMIT_FILE = "timelimit.json"
 DATA_FILE = "timeusage.json"
 EXCEPTION_FILE = "exceptionaltime.json"
+NIGHT_LOCKDOWN_FILE = "nightlockdown.json"
 
 # Days of week mapping
 DAYS_OF_WEEK = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+
+def default_night_lockdown():
+    """Return a disabled default night-lockdown configuration."""
+    return {
+        "enabled": False,
+        "per_day": False,
+        "all_days": {"blocked": [], "whitelist": []},
+        "days": {day: {"blocked": [], "whitelist": []} for day in DAYS_OF_WEEK},
+    }
 
 
 # ============================================================================
@@ -47,6 +58,7 @@ def ensure_files_exist() -> None:
         (LIMIT_FILE, {}),
         (DATA_FILE, {}),
         (EXCEPTION_FILE, {}),
+        (NIGHT_LOCKDOWN_FILE, default_night_lockdown()),
     ]
     for file_path, default in defaults:
         if not os.path.exists(file_path):
@@ -104,6 +116,82 @@ def save_exceptions(exceptions: Dict[str, Any]) -> bool:
     except Exception as e:
         print(f"Error saving exceptions: {e}")
         return False
+
+
+def load_night_lockdown() -> Dict[str, Any]:
+    """Load night lockdown config from file, merging with defaults."""
+    try:
+        with open(NIGHT_LOCKDOWN_FILE, "r") as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default_night_lockdown()
+
+    config = default_night_lockdown()
+    if isinstance(data, dict):
+        config["enabled"] = bool(data.get("enabled", False))
+        config["per_day"] = bool(data.get("per_day", False))
+        if isinstance(data.get("all_days"), dict):
+            config["all_days"]["blocked"] = data["all_days"].get("blocked", []) or []
+            config["all_days"]["whitelist"] = data["all_days"].get("whitelist", []) or []
+        if isinstance(data.get("days"), dict):
+            for day in DAYS_OF_WEEK:
+                day_cfg = data["days"].get(day)
+                if isinstance(day_cfg, dict):
+                    config["days"][day]["blocked"] = day_cfg.get("blocked", []) or []
+                    config["days"][day]["whitelist"] = day_cfg.get("whitelist", []) or []
+    return config
+
+
+def save_night_lockdown(config: Dict[str, Any]) -> bool:
+    """Save night lockdown config to file."""
+    try:
+        with open(NIGHT_LOCKDOWN_FILE, "w") as f:
+            json.dump(config, f, indent=2)
+        return True
+    except Exception as e:
+        print(f"Error saving night lockdown config: {e}")
+        return False
+
+
+def _valid_time_string(value: Any) -> bool:
+    """Return True if value is a valid 'HH:MM' 24-hour time string."""
+    try:
+        hours, minutes = str(value).split(":")
+        hours, minutes = int(hours), int(minutes)
+        return 0 <= hours <= 23 and 0 <= minutes <= 59
+    except Exception:
+        return False
+
+
+def _normalize_windows(windows: Any) -> Tuple[bool, Any]:
+    """Validate and normalize a list of [start, end] time windows.
+
+    Returns (is_valid, normalized_list_or_error_message).
+    """
+    if not isinstance(windows, list):
+        return False, "Time windows must be a list"
+    normalized = []
+    for window in windows:
+        if not isinstance(window, (list, tuple)) or len(window) != 2:
+            return False, "Each window must be a [start, end] pair"
+        start, end = window[0], window[1]
+        if not _valid_time_string(start) or not _valid_time_string(end):
+            return False, f"Invalid time value in window {window}. Use HH:MM (24h)"
+        normalized.append([start, end])
+    return True, normalized
+
+
+def _normalize_schedule(schedule: Any) -> Tuple[bool, Any]:
+    """Validate a {'blocked': [...], 'whitelist': [...]} schedule object."""
+    if not isinstance(schedule, dict):
+        return False, "Schedule must be an object with 'blocked' and 'whitelist'"
+    result = {}
+    for key in ("blocked", "whitelist"):
+        ok, value = _normalize_windows(schedule.get(key, []))
+        if not ok:
+            return False, value
+        result[key] = value
+    return True, result
 
 
 # ============================================================================
@@ -388,6 +476,65 @@ def delete_exception_transaction(date, app_name, index):
 
 
 # ============================================================================
+# NIGHT LOCKDOWN ENDPOINTS
+# ============================================================================
+
+@app.route("/api/nightlockdown", methods=["GET"])
+def get_night_lockdown():
+    """Get the full night lockdown configuration."""
+    config = load_night_lockdown()
+    return jsonify({"status": "success", "data": config}), 200
+
+
+@app.route("/api/nightlockdown", methods=["PUT"])
+def update_night_lockdown():
+    """
+    Replace the full night lockdown configuration.
+
+    Body:
+    {
+        "enabled": true,
+        "per_day": false,
+        "all_days": {
+            "blocked":   [["22:00", "07:00"]],
+            "whitelist": [["23:00", "23:30"]]
+        },
+        "days": {
+            "Monday": {"blocked": [], "whitelist": []},
+            ...
+        }
+    }
+    """
+    data = request.get_json()
+
+    if not data or not isinstance(data, dict):
+        return jsonify({"status": "error", "message": "No data provided"}), 400
+
+    config = default_night_lockdown()
+    config["enabled"] = bool(data.get("enabled", False))
+    config["per_day"] = bool(data.get("per_day", False))
+
+    # Validate the shared (all-days) schedule
+    ok, all_days = _normalize_schedule(data.get("all_days", {"blocked": [], "whitelist": []}))
+    if not ok:
+        return jsonify({"status": "error", "message": f"all_days: {all_days}"}), 400
+    config["all_days"] = all_days
+
+    # Validate each per-day schedule
+    days_in = data.get("days", {}) or {}
+    for day in DAYS_OF_WEEK:
+        ok, day_schedule = _normalize_schedule(days_in.get(day, {"blocked": [], "whitelist": []}))
+        if not ok:
+            return jsonify({"status": "error", "message": f"{day}: {day_schedule}"}), 400
+        config["days"][day] = day_schedule
+
+    if save_night_lockdown(config):
+        return jsonify({"status": "success", "message": "Night lockdown configuration updated", "data": config}), 200
+    else:
+        return jsonify({"status": "error", "message": "Failed to save night lockdown configuration"}), 500
+
+
+# ============================================================================
 # USAGE ENDPOINTS
 # ============================================================================
 
@@ -483,15 +630,17 @@ def get_status():
 
 @app.route("/api/config", methods=["GET"])
 def get_config():
-    """Get full configuration (limits and exceptions)."""
+    """Get full configuration (limits, exceptions and night lockdown)."""
     limits = load_limits()
     exceptions = load_exceptions()
-    
+    night_lockdown = load_night_lockdown()
+
     return jsonify({
         "status": "success",
         "data": {
             "limits": limits,
-            "exceptions": exceptions
+            "exceptions": exceptions,
+            "night_lockdown": night_lockdown
         }
     }), 200
 
@@ -514,14 +663,18 @@ def upload_config():
     
     limits_saved = True
     exceptions_saved = True
-    
+    night_lockdown_saved = True
+
     if "limits" in data:
         limits_saved = save_limits(data["limits"])
-    
+
     if "exceptions" in data:
         exceptions_saved = save_exceptions(data["exceptions"])
-    
-    if limits_saved and exceptions_saved:
+
+    if "night_lockdown" in data:
+        night_lockdown_saved = save_night_lockdown(data["night_lockdown"])
+
+    if limits_saved and exceptions_saved and night_lockdown_saved:
         return jsonify({"status": "success", "message": "Configuration uploaded successfully"}), 200
     else:
         return jsonify({"status": "error", "message": "Failed to save configuration"}), 500
@@ -562,6 +715,8 @@ if __name__ == "__main__":
     print("  GET    /api/exceptions/<date>/<app_name>")
     print("  POST   /api/exceptions")
     print("  DELETE /api/exceptions/<date>/<app_name>")
+    print("  GET    /api/nightlockdown")
+    print("  PUT    /api/nightlockdown")
     print("  GET    /api/usage")
     print("  GET    /api/usage/<date>")
     print("  GET    /api/usage/<date>/<app_name>")

--- a/clientside/client_engine.py
+++ b/clientside/client_engine.py
@@ -18,6 +18,11 @@ DATA_FILE = "timeusage.json"
 EXCEPTION_FILE = "exceptionaltime.json"
 USED_EXCEPTIONS_FILE = "used_exceptions.json"
 CHECK_INTERVAL = 5  # seconds
+# When an app (or OVERALL) has no limit configured for the current day — the key
+# is missing or explicitly null — treat it as effectively unlimited for that day
+# so the engine never restricts something the parent didn't set up. An explicit
+# 0 still means "disabled for that day". 86399 = seconds in a day minus one.
+UNCONFIGURED_LIMIT = 24 * 60 * 60 - 1
 load_dotenv()
 HASS_URL = os.getenv("HASS_URL","http://homeassistant.local:8123")
 TOKEN = os.getenv("HASS_TOKEN")
@@ -257,9 +262,13 @@ def main():
         for name,procs in found_processes.items():
             if today not in list(usage):
                 usage[today] = {}
-            # Safely get the configured limit for the name (handles missing entries)
+            # Safely get the configured limit for the name (handles missing entries).
+            # A missing/null value for today means "not configured" -> effectively
+            # unlimited for the day, so unconfigured apps/OVERALL are not restricted.
+            # An explicit 0 is preserved and still means "disabled for that day".
             name_limits = limits.get(name) or {}
-            app_lim = name_limits.get(dow, 0)
+            configured_lim = name_limits.get(dow, None)
+            app_lim = UNCONFIGURED_LIMIT if configured_lim is None else configured_lim
 
             # Always treat missing usage as 0 so exceptions (including OVERALL) apply immediately
             app_usg = usage.get(today, {}).get(name, 0)

--- a/clientside/client_master.py
+++ b/clientside/client_master.py
@@ -2,11 +2,12 @@ import subprocess
 import sys
 import time
 
-# 1. Start both processes
+# 1. Start all processes
 api_process = subprocess.Popen([sys.executable, 'api.py'])
 main_process = subprocess.Popen([sys.executable, 'client_engine.py'])
+night_lockdown_process = subprocess.Popen([sys.executable, 'night_lockdown.py'])
 
-print("Both processes are running. Press Ctrl+C to stop both.")
+print("All processes are running. Press Ctrl+C to stop them all.")
 
 try:
     # 2. Keep the parent script alive so the children don't get orphaned
@@ -18,6 +19,9 @@ try:
         if main_process.poll() is not None:
             print("Main engine died. Exiting...")
             break
+        if night_lockdown_process.poll() is not None:
+            print("Night lockdown engine died. Exiting...")
+            break
         time.sleep(1)
 
 except KeyboardInterrupt:
@@ -25,4 +29,5 @@ except KeyboardInterrupt:
     print("\nStopping processes...")
     api_process.terminate()
     main_process.terminate()
+    night_lockdown_process.terminate()
     sys.exit()

--- a/clientside/night_lockdown.py
+++ b/clientside/night_lockdown.py
@@ -1,0 +1,224 @@
+"""
+Night Lockdown Engine for Parental Control
+
+Monitors the current time against parent-defined blocked and whitelisted time
+zones. When the computer is turned on inside a blocked window (and not inside a
+whitelisted window that overrides it), the computer is shut down.
+
+Configuration is stored in ``nightlockdown.json`` and can be managed through the
+REST API / web dashboard.  The schedule may be the same for every day of the
+week, or configured individually for each day of the week — the parent decides
+via the ``per_day`` flag.
+
+Config format (nightlockdown.json)::
+
+    {
+        "enabled": true,
+        "per_day": false,
+        "all_days": {
+            "blocked":   [["22:00", "07:00"]],
+            "whitelist": [["23:00", "23:30"]]
+        },
+        "days": {
+            "Monday":    {"blocked": [], "whitelist": []},
+            "Tuesday":   {"blocked": [], "whitelist": []},
+            "Wednesday": {"blocked": [], "whitelist": []},
+            "Thursday":  {"blocked": [], "whitelist": []},
+            "Friday":    {"blocked": [], "whitelist": []},
+            "Saturday":  {"blocked": [], "whitelist": []},
+            "Sunday":    {"blocked": [], "whitelist": []}
+        }
+    }
+
+A time window is a ``["HH:MM", "HH:MM"]`` pair.  Windows may wrap past midnight
+(e.g. ``["22:00", "07:00"]`` means 22:00 through 07:00 the next morning).
+"""
+
+import json
+import os
+import time
+from datetime import datetime
+
+try:
+    from win11toast import toast
+except Exception:  # pragma: no cover - toast is optional / Windows-only
+    toast = None
+
+NIGHT_LOCKDOWN_FILE = "nightlockdown.json"
+CHECK_INTERVAL = 15  # seconds between checks
+SAFETY_SLEEP = 180   # 3 minutes security sleep when the module opens
+
+DAYS_OF_WEEK = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+ISO_DAY_MAP = {1: "Monday", 2: "Tuesday", 3: "Wednesday", 4: "Thursday",
+               5: "Friday", 6: "Saturday", 7: "Sunday"}
+
+
+def default_config():
+    """Return a disabled default night-lockdown configuration."""
+    return {
+        "enabled": False,
+        "per_day": False,
+        "all_days": {"blocked": [], "whitelist": []},
+        "days": {day: {"blocked": [], "whitelist": []} for day in DAYS_OF_WEEK},
+    }
+
+
+def ensure_files_exist():
+    """Create the night lockdown config file with defaults if it is missing."""
+    if not os.path.exists(NIGHT_LOCKDOWN_FILE):
+        try:
+            with open(NIGHT_LOCKDOWN_FILE, "w") as f:
+                json.dump(default_config(), f, indent=2)
+        except Exception as e:
+            print(f"Warning: Could not create {NIGHT_LOCKDOWN_FILE}: {e}")
+
+
+def load_config():
+    """Load night lockdown config, falling back to defaults on error."""
+    try:
+        with open(NIGHT_LOCKDOWN_FILE, "r") as f:
+            data = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default_config()
+
+    # Merge with defaults so missing keys never crash the engine
+    config = default_config()
+    if isinstance(data, dict):
+        config["enabled"] = bool(data.get("enabled", False))
+        config["per_day"] = bool(data.get("per_day", False))
+        if isinstance(data.get("all_days"), dict):
+            config["all_days"]["blocked"] = data["all_days"].get("blocked", []) or []
+            config["all_days"]["whitelist"] = data["all_days"].get("whitelist", []) or []
+        if isinstance(data.get("days"), dict):
+            for day in DAYS_OF_WEEK:
+                day_cfg = data["days"].get(day)
+                if isinstance(day_cfg, dict):
+                    config["days"][day]["blocked"] = day_cfg.get("blocked", []) or []
+                    config["days"][day]["whitelist"] = day_cfg.get("whitelist", []) or []
+    return config
+
+
+def _time_to_minutes(value):
+    """Convert an 'HH:MM' string to minutes since midnight. Returns None if invalid."""
+    try:
+        hours, minutes = str(value).split(":")
+        hours, minutes = int(hours), int(minutes)
+        if 0 <= hours <= 23 and 0 <= minutes <= 59:
+            return hours * 60 + minutes
+    except Exception:
+        pass
+    return None
+
+
+def _in_window(now_minutes, start, end):
+    """
+    Return True if now_minutes falls inside the [start, end] window.
+
+    Supports windows that wrap past midnight (start > end), e.g. 22:00 -> 07:00.
+    """
+    if start is None or end is None:
+        return False
+    if start <= end:
+        return start <= now_minutes <= end
+    # Wraps past midnight
+    return now_minutes >= start or now_minutes <= end
+
+
+def _matches_any_window(now_minutes, windows):
+    """Return True if now_minutes is inside any of the given time windows."""
+    if not isinstance(windows, list):
+        return False
+    for window in windows:
+        if isinstance(window, (list, tuple)) and len(window) == 2:
+            start = _time_to_minutes(window[0])
+            end = _time_to_minutes(window[1])
+            if _in_window(now_minutes, start, end):
+                return True
+    return False
+
+
+def get_active_schedule(config, day):
+    """Return the {'blocked', 'whitelist'} schedule that applies for the given day."""
+    if config.get("per_day"):
+        return config.get("days", {}).get(day, {"blocked": [], "whitelist": []})
+    return config.get("all_days", {"blocked": [], "whitelist": []})
+
+
+def is_locked_down(config, now=None):
+    """
+    Determine whether the current moment falls inside a blocked window.
+
+    A moment is "locked down" when it is inside a blocked window AND NOT inside
+    a whitelisted window (whitelist overrides blocked).
+    """
+    if not config.get("enabled"):
+        return False
+
+    now = now or datetime.now()
+    day = ISO_DAY_MAP.get(now.isoweekday())
+    now_minutes = now.hour * 60 + now.minute
+
+    schedule = get_active_schedule(config, day)
+    blocked = schedule.get("blocked", [])
+    whitelist = schedule.get("whitelist", [])
+
+    if _matches_any_window(now_minutes, blocked):
+        # Whitelisted windows carve exceptions out of blocked windows
+        if _matches_any_window(now_minutes, whitelist):
+            return False
+        return True
+    return False
+
+
+def notify_shutdown():
+    """Best-effort toast warning the user before the computer shuts down."""
+    if toast is None:
+        return
+    try:
+        toast(
+            "HASSS Agent",
+            "Gece kilidi aktif. Bilgisayar kapatılıyor.",
+            scenario="urgent",
+        )
+    except Exception as e:
+        print(f"Failed to send night lockdown notification: {e}")
+
+
+def shutdown():
+    """Force an immediate shutdown of the computer."""
+    print("Night lockdown active. Shutting down the computer.")
+    notify_shutdown()
+    os.system("shutdown /s /t 0 /F")
+
+
+def main():
+    ensure_files_exist()
+    print(f"Night Lockdown started -- Waiting {SAFETY_SLEEP} seconds for security.")
+    time.sleep(SAFETY_SLEEP)
+    print("Night Lockdown monitoring started.\n")
+
+    while True:
+        config = load_config()
+        if is_locked_down(config):
+            shutdown()
+            # Give the shutdown command time to take effect before looping again
+            time.sleep(CHECK_INTERVAL)
+        else:
+            if config.get("enabled"):
+                print(f"Night lockdown check passed at {datetime.now().strftime('%H:%M:%S')}")
+            else:
+                print("Night lockdown disabled.")
+        time.sleep(CHECK_INTERVAL)
+
+
+if __name__ == "__main__":
+    while True:
+        try:
+            main()
+        except KeyboardInterrupt:
+            print("Exiting due to KeyboardInterrupt.")
+            break
+        except Exception as e:
+            print(f"Error in night lockdown loop: {e}")
+            time.sleep(2)
+            continue

--- a/serverside/SECONDARY_API_DOCS.md
+++ b/serverside/SECONDARY_API_DOCS.md
@@ -88,6 +88,9 @@ DELETE /api/exceptions/<date>/<app>
 GET    /api/usage
 PUT    /api/usage/<date>/<app>
 
+GET    /api/nightlockdown
+PUT    /api/nightlockdown
+
 GET    /api/config
 POST   /api/config
 ```

--- a/serverside/dashboard.html
+++ b/serverside/dashboard.html
@@ -360,6 +360,58 @@
             }
         }
 
+        .nl-card {
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 20px;
+            margin-bottom: 20px;
+            background: #fafafa;
+        }
+
+        .nl-card h3 {
+            color: #333;
+            margin-bottom: 15px;
+        }
+
+        .nl-subtitle {
+            font-weight: 600;
+            color: #444;
+            margin: 15px 0 8px;
+        }
+
+        .nl-subtitle small {
+            font-weight: 400;
+            color: #999;
+        }
+
+        .nl-row {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 10px;
+            flex-wrap: wrap;
+        }
+
+        .nl-row input[type="time"] {
+            width: auto;
+            flex: 0 0 auto;
+        }
+
+        .nl-row .nl-sep {
+            color: #666;
+        }
+
+        .nl-empty {
+            color: #999;
+            font-style: italic;
+            margin-bottom: 10px;
+        }
+
+        .nl-add-btn {
+            padding: 6px 12px;
+            font-size: 0.85em;
+        }
+
         .loading {
             display: none;
             text-align: center;
@@ -433,6 +485,7 @@
         <div class="nav-tabs">
             <button class="tab-btn active" data-tab="limits">⏱️ Time Limits</button>
             <button class="tab-btn" data-tab="exceptions">✨ Exceptions</button>
+            <button class="tab-btn" data-tab="nightlockdown">🌙 Night Lockdown</button>
             <button class="tab-btn" data-tab="usage">📊 Usage</button>
             <button class="tab-btn" data-tab="config">⚙️ Configuration</button>
         </div>
@@ -539,6 +592,44 @@
                         <div class="spinner"></div>
                     </div>
                     <div id="exceptionsTable" class="table-responsive"></div>
+                </div>
+            </div>
+
+            <!-- NIGHT LOCKDOWN TAB -->
+            <div id="nightlockdown" class="tab-content">
+                <div id="alertNightLockdown" class="alert"></div>
+
+                <div class="section">
+                    <h2>Night Lockdown</h2>
+                    <p style="color: #666; margin-bottom: 20px;">
+                        Define <strong>blocked zones</strong> — time windows during which the computer will
+                        automatically shut down if it is turned on. <strong>Whitelisted zones</strong> carve
+                        out allowed periods inside a blocked zone. Time windows may cross midnight
+                        (e.g. 22:00 → 07:00).
+                    </p>
+
+                    <div id="nightLockdownLoading" class="loading">
+                        <div class="spinner"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                            <input type="checkbox" id="nlEnabled" style="width: auto;" onchange="onNlEnabledChange();">
+                            <span>Enable night lockdown</span>
+                        </label>
+                    </div>
+
+                    <div class="form-group">
+                        <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
+                            <input type="checkbox" id="nlPerDay" style="width: auto;" onchange="onNlPerDayChange();">
+                            <span>Use a different schedule for each day of the week</span>
+                        </label>
+                        <small style="color: #999;">When off, the same blocked/whitelisted zones apply to every day.</small>
+                    </div>
+
+                    <div id="nlEditors"></div>
+
+                    <button type="button" class="btn-primary" onclick="saveNightLockdown();" style="margin-top: 20px;">💾 Save Night Lockdown</button>
                 </div>
             </div>
 
@@ -791,6 +882,7 @@
             document.getElementById('limitsLoading').classList.add('show');
             document.getElementById('exceptionsLoading').classList.add('show');
             document.getElementById('configLoading').classList.add('show');
+            document.getElementById('nightLockdownLoading').classList.add('show');
 
             let batchSuccess = false;
             try {
@@ -832,6 +924,11 @@
                         document.getElementById('configData').value = JSON.stringify(d.config, null, 2);
                     }
 
+                    // Populate night lockdown settings
+                    if ('night_lockdown' in d) {
+                        setNightLockdownData(d.night_lockdown);
+                    }
+
                     batchSuccess = true;
                 }
             } catch (error) {
@@ -841,11 +938,12 @@
                 document.getElementById('limitsLoading').classList.remove('show');
                 document.getElementById('exceptionsLoading').classList.remove('show');
                 document.getElementById('configLoading').classList.remove('show');
+                document.getElementById('nightLockdownLoading').classList.remove('show');
             }
 
             if (!batchSuccess) {
                 // Fallback: fire all requests in parallel
-                await Promise.all([loadStatus(), loadLimits(), loadExceptions(), loadConfig()]);
+                await Promise.all([loadStatus(), loadLimits(), loadExceptions(), loadConfig(), loadNightLockdown()]);
             }
         }
 
@@ -1407,6 +1505,180 @@
             };
             reader.readAsText(file);
             document.getElementById('configFile').value = '';
+        }
+
+        // NIGHT LOCKDOWN MANAGEMENT
+        let nightLockdownState = null;
+
+        function defaultNightLockdown() {
+            const days = {};
+            DAYS.forEach(d => { days[d] = { blocked: [], whitelist: [] }; });
+            return { enabled: false, per_day: false, all_days: { blocked: [], whitelist: [] }, days };
+        }
+
+        // Merge server data with defaults so missing keys never break rendering
+        function normalizeNightLockdown(cfg) {
+            const result = defaultNightLockdown();
+            if (cfg && typeof cfg === 'object') {
+                result.enabled = !!cfg.enabled;
+                result.per_day = !!cfg.per_day;
+                if (cfg.all_days && typeof cfg.all_days === 'object') {
+                    result.all_days.blocked = Array.isArray(cfg.all_days.blocked) ? cfg.all_days.blocked : [];
+                    result.all_days.whitelist = Array.isArray(cfg.all_days.whitelist) ? cfg.all_days.whitelist : [];
+                }
+                if (cfg.days && typeof cfg.days === 'object') {
+                    DAYS.forEach(day => {
+                        const dc = cfg.days[day];
+                        if (dc && typeof dc === 'object') {
+                            result.days[day].blocked = Array.isArray(dc.blocked) ? dc.blocked : [];
+                            result.days[day].whitelist = Array.isArray(dc.whitelist) ? dc.whitelist : [];
+                        }
+                    });
+                }
+            }
+            return result;
+        }
+
+        function setNightLockdownData(cfg) {
+            nightLockdownState = normalizeNightLockdown(cfg);
+            renderNightLockdown();
+        }
+
+        async function loadNightLockdown() {
+            document.getElementById('nightLockdownLoading').classList.add('show');
+            try {
+                const response = await fetch(`${API_URL}/nightlockdown`);
+                const data = await response.json();
+                setNightLockdownData(data.data);
+            } catch (error) {
+                console.error('Error loading night lockdown:', error);
+                setNightLockdownData(defaultNightLockdown());
+            } finally {
+                document.getElementById('nightLockdownLoading').classList.remove('show');
+            }
+        }
+
+        function getScheduleByScope(scopeKey) {
+            if (!nightLockdownState) nightLockdownState = defaultNightLockdown();
+            return scopeKey === 'all' ? nightLockdownState.all_days : nightLockdownState.days[scopeKey];
+        }
+
+        function windowRowsHtml(scopeKey, type, windows) {
+            if (!Array.isArray(windows) || windows.length === 0) {
+                return `<div class="nl-empty">No ${type === 'blocked' ? 'blocked' : 'whitelisted'} zones.</div>`;
+            }
+            let html = '';
+            windows.forEach((win, i) => {
+                const start = (Array.isArray(win) && win[0]) ? win[0] : '';
+                const end = (Array.isArray(win) && win[1]) ? win[1] : '';
+                html += `
+                    <div class="nl-row">
+                        <input type="time" value="${start}" onchange="updateWindow('${scopeKey}','${type}',${i},0,this.value);">
+                        <span class="nl-sep">to</span>
+                        <input type="time" value="${end}" onchange="updateWindow('${scopeKey}','${type}',${i},1,this.value);">
+                        <button type="button" class="btn-danger nl-add-btn" onclick="removeWindow('${scopeKey}','${type}',${i});">Remove</button>
+                    </div>
+                `;
+            });
+            return html;
+        }
+
+        function scheduleEditorHtml(scopeKey, title, schedule) {
+            return `
+                <div class="nl-card">
+                    <h3>${title}</h3>
+                    <div class="nl-subtitle">🚫 Blocked zones <small>(computer shuts down during these times)</small></div>
+                    ${windowRowsHtml(scopeKey, 'blocked', schedule.blocked)}
+                    <button type="button" class="btn-secondary nl-add-btn" onclick="addWindow('${scopeKey}','blocked');">+ Add blocked zone</button>
+                    <div class="nl-subtitle">✅ Whitelisted zones <small>(allowed even inside a blocked zone)</small></div>
+                    ${windowRowsHtml(scopeKey, 'whitelist', schedule.whitelist)}
+                    <button type="button" class="btn-secondary nl-add-btn" onclick="addWindow('${scopeKey}','whitelist');">+ Add whitelist zone</button>
+                </div>
+            `;
+        }
+
+        function renderNightLockdown() {
+            if (!nightLockdownState) nightLockdownState = defaultNightLockdown();
+            document.getElementById('nlEnabled').checked = !!nightLockdownState.enabled;
+            document.getElementById('nlPerDay').checked = !!nightLockdownState.per_day;
+
+            const container = document.getElementById('nlEditors');
+            let html = '';
+            if (nightLockdownState.per_day) {
+                DAYS.forEach(day => {
+                    html += scheduleEditorHtml(day, day, nightLockdownState.days[day]);
+                });
+            } else {
+                html = scheduleEditorHtml('all', 'Every Day', nightLockdownState.all_days);
+            }
+            container.innerHTML = html;
+        }
+
+        function onNlEnabledChange() {
+            if (!nightLockdownState) nightLockdownState = defaultNightLockdown();
+            nightLockdownState.enabled = document.getElementById('nlEnabled').checked;
+        }
+
+        function onNlPerDayChange() {
+            if (!nightLockdownState) nightLockdownState = defaultNightLockdown();
+            nightLockdownState.per_day = document.getElementById('nlPerDay').checked;
+            renderNightLockdown();
+        }
+
+        function addWindow(scopeKey, type) {
+            const schedule = getScheduleByScope(scopeKey);
+            schedule[type].push(['22:00', '07:00']);
+            renderNightLockdown();
+        }
+
+        function removeWindow(scopeKey, type, index) {
+            const schedule = getScheduleByScope(scopeKey);
+            schedule[type].splice(index, 1);
+            renderNightLockdown();
+        }
+
+        function updateWindow(scopeKey, type, index, field, value) {
+            const schedule = getScheduleByScope(scopeKey);
+            if (!Array.isArray(schedule[type][index])) return;
+            schedule[type][index][field] = value;
+        }
+
+        async function saveNightLockdown() {
+            if (!nightLockdownState) nightLockdownState = defaultNightLockdown();
+
+            // Validate: every window must have both a start and end time
+            const scopes = nightLockdownState.per_day
+                ? DAYS.map(d => [d, nightLockdownState.days[d]])
+                : [['Every Day', nightLockdownState.all_days]];
+            for (const [label, schedule] of scopes) {
+                for (const type of ['blocked', 'whitelist']) {
+                    for (const win of schedule[type]) {
+                        if (!win[0] || !win[1]) {
+                            showAlert('alertNightLockdown', `❌ ${label}: every zone needs both a start and end time.`, 'error');
+                            return;
+                        }
+                    }
+                }
+            }
+
+            try {
+                const response = await fetch(`${API_URL}/nightlockdown`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(nightLockdownState)
+                });
+                const data = await response.json();
+                if (response.status === 202) {
+                    showAlert('alertNightLockdown', '⏳ Night lockdown queued — will be applied when the primary API is back online.', 'warning');
+                } else if (response.ok) {
+                    showAlert('alertNightLockdown', '✅ Night lockdown settings saved!', 'success');
+                    loadConfig();
+                } else {
+                    showAlert('alertNightLockdown', `❌ Error: ${data.message}`, 'error');
+                }
+            } catch (error) {
+                showAlert('alertNightLockdown', `❌ Error: ${error.message}`, 'error');
+            }
         }
 
         // Utility functions

--- a/serverside/secondary_api.py
+++ b/serverside/secondary_api.py
@@ -465,6 +465,15 @@ def delete_exception_transaction_proxy(date, app_name, index):
     """Proxy delete for a specific exception transaction (queues when primary offline)."""
     return proxy_request('DELETE', f'/exceptions/{date}/{app_name}/{index}', return_queued=True)
 
+# NIGHT LOCKDOWN ENDPOINTS
+@app.route("/api/nightlockdown", methods=["GET"])
+def get_night_lockdown():
+    return proxy_request('GET', '/nightlockdown')
+
+@app.route("/api/nightlockdown", methods=["PUT"])
+def update_night_lockdown():
+    return proxy_request('PUT', '/nightlockdown', request.get_json(), return_queued=True)
+
 # USAGE ENDPOINTS
 @app.route("/api/usage", methods=["GET"])
 def get_usage():
@@ -511,6 +520,7 @@ def get_dashboard_data():
         'status': '/status',
         'today_exceptions': f'/exceptions/{today}',
         'config': '/config',
+        'night_lockdown': '/nightlockdown',
     }
 
     def fetch_one(key, endpoint):
@@ -712,7 +722,8 @@ def refresh_cache():
         f'/exceptions/{today}',
         f'/usage/{today}',
         '/config',
-        '/status'
+        '/status',
+        '/nightlockdown'
     ]
     
     for endpoint in endpoints_to_cache:


### PR DESCRIPTION
Adds a night lockdown feature that shuts the computer down when it is used
during parent-defined blocked time zones.

Client side:
- night_lockdown.py: standalone engine that reads nightlockdown.json, checks
  the current time against blocked/whitelisted windows (whitelist overrides
  blocked, windows may cross midnight) and shuts down when locked out. Performs
  a 3-minute security sleep on startup.
- client_master.py: launches the night lockdown engine alongside the API and
  monitoring engine.

APIs:
- clientside/api.py: GET/PUT /api/nightlockdown with validation, plus inclusion
  in the /api/config download/upload payload.
- serverside/secondary_api.py: proxy + offline-queue support for the new
  endpoints, and caching in the batch dashboard endpoint.

Dashboard:
- serverside/dashboard.html: new "Night Lockdown" tab to enable the feature,
  choose a shared or per-day schedule, and manage blocked/whitelisted zones.

Config supports either the same schedule for every day (all_days) or a
different schedule per weekday (days), toggled by the per_day flag.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011yox1quU7zZQB7vjUFF3Hn